### PR TITLE
Peter

### DIFF
--- a/src/app/pages/bills/bills.component.html
+++ b/src/app/pages/bills/bills.component.html
@@ -44,7 +44,12 @@
               <table class="table mx-auto w-auto">
                 <thead class="text-info">
                   <tr>
-                    <th (click)="onColumnSelect(col.key)" *ngFor="let col of cols">{{ col.title }}</th>
+                    <th (click)="onColumnSelect(col.key)" *ngFor="let col of cols">
+                      <i *ngIf="columnKey === col.key && (col.key === 'id' || col.key === 'orderID' || col.key === 'amount') && sortDir === 1" class="fa fa-sort-numeric-asc"></i>
+                      <i *ngIf="columnKey === col.key && (col.key === 'id' || col.key === 'orderID' || col.key === 'amount') && sortDir === -1" class="fa fa-sort-numeric-desc"></i>
+                      <i *ngIf="columnKey === col.key && (col.key === 'status') && sortDir === 1" class="fa fa-sort-alpha-asc"></i>
+                      <i *ngIf="columnKey === col.key && (col.key === 'status') && sortDir === -1" class="fa fa-sort-alpha-desc"></i>
+                      {{ col.title }}</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/app/pages/bills/bills.component.scss
+++ b/src/app/pages/bills/bills.component.scss
@@ -105,9 +105,10 @@
 }
 
 thead {
-    th:first-child, th:nth-child(2), th:nth-child(3), th:nth-child(4) {
-        &:hover {
-            cursor: pointer
-        }
+    cursor: pointer;  
+    user-select: none;
+  
+    th:last-child {
+        cursor: default;
     }
-}
+  }

--- a/src/app/pages/customers/customers.component.html
+++ b/src/app/pages/customers/customers.component.html
@@ -46,7 +46,12 @@
               <table class="table mx-auto w-auto">
                 <thead class="text-success">
                   <tr>
-                    <th (click)="onColumnSelect(col.key)" *ngFor="let col of cols">{{ col.title }}</th>
+                    <th (click)="onColumnSelect(col.key)" *ngFor="let col of cols">
+                      <i *ngIf="columnKey === col.key && (col.key === 'id' || col.key === 'address') && sortDir === 1" class="fa fa-sort-numeric-asc"></i>
+                      <i *ngIf="columnKey === col.key && (col.key === 'id' || col.key === 'address') && sortDir === -1" class="fa fa-sort-numeric-desc"></i>
+                      <i *ngIf="columnKey === col.key && (col.key === 'firstName' || col.key === 'lastName' || col.key === 'email' || col.key === 'active') && sortDir === 1" class="fa fa-sort-alpha-asc"></i>
+                      <i *ngIf="columnKey === col.key && (col.key === 'firstName' || col.key === 'lastName' || col.key === 'email' || col.key === 'active') && sortDir === -1" class="fa fa-sort-alpha-desc"></i>
+                      {{ col.title }}</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/app/pages/customers/customers.component.scss
+++ b/src/app/pages/customers/customers.component.scss
@@ -108,9 +108,10 @@
 };
 
 thead {
-  th:first-child, th:nth-child(2), th:nth-child(3), th:nth-child(4), th:nth-child(5), th:nth-child(6) {
-      &:hover {
-          cursor: pointer
-      }
+  cursor: pointer;  
+  user-select: none;
+
+  th:last-child {
+      cursor: default;
   }
 }

--- a/src/app/pages/orders/orders.component.html
+++ b/src/app/pages/orders/orders.component.html
@@ -46,7 +46,12 @@
               <table class="table mx-auto w-auto">
                 <thead class="text-info">
                   <tr>
-                    <th (click)="onColumnSelect(col.key)" *ngFor="let col of cols">{{ col.title }}</th>
+                    <th (click)="onColumnSelect(col.key)" *ngFor="let col of cols">
+                      <i *ngIf="columnKey === col.key && (col.key === 'id' || col.key === 'customerID' || col.key === 'productID' || col.key === 'amount') && sortDir === 1" class="fa fa-sort-numeric-asc"></i>
+                      <i *ngIf="columnKey === col.key && (col.key === 'id' || col.key === 'customerID' || col.key === 'productID' || col.key === 'amount') && sortDir === -1" class="fa fa-sort-numeric-desc"></i>
+                      <i *ngIf="columnKey === col.key && (col.key === 'status') && sortDir === 1" class="fa fa-sort-alpha-asc"></i>
+                      <i *ngIf="columnKey === col.key && (col.key === 'status') && sortDir === -1" class="fa fa-sort-alpha-desc"></i>
+                      {{ col.title }}</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/app/pages/orders/orders.component.scss
+++ b/src/app/pages/orders/orders.component.scss
@@ -110,9 +110,10 @@
 }
 
 thead {
-  th:first-child, th:nth-child(2), th:nth-child(3), th:nth-child(4), th:nth-child(5) {
-      &:hover {
-          cursor: pointer
-      }
+  cursor: pointer;  
+  user-select: none;
+
+  th:last-child {
+      cursor: default;
   }
 }

--- a/src/app/pages/products/products.component.html
+++ b/src/app/pages/products/products.component.html
@@ -45,8 +45,13 @@
             <div class="card-content table-responsive">
               <table class="table mx-auto w-auto">
                 <thead class="text-warning">
-                  <tr>
-                    <th (click)="onColumnSelect(col.key)" *ngFor="let col of cols">{{ col.title }}</th>
+                  <tr>                    
+                    <th (click)="onColumnSelect(col.key)" *ngFor="let col of cols">
+                      <i *ngIf="columnKey === col.key && (col.key === 'id' || col.key === 'address' || col.key === 'catID' || col.key === 'price') && sortDir === 1" class="fa fa-sort-numeric-asc"></i>
+                      <i *ngIf="columnKey === col.key && (col.key === 'id' || col.key === 'address' || col.key === 'catID' || col.key === 'price') && sortDir === -1" class="fa fa-sort-numeric-desc"></i>
+                      <i *ngIf="columnKey === col.key && (col.key === 'name' || col.key === 'type' || col.key === 'description' || col.key === 'featured' || col.key === 'active') && sortDir === 1" class="fa fa-sort-alpha-asc"></i>
+                      <i *ngIf="columnKey === col.key && (col.key === 'name' || col.key === 'type' || col.key === 'description' || col.key === 'featured' || col.key === 'active') && sortDir === -1" class="fa fa-sort-alpha-desc"></i>
+                      {{ col.title }}</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/app/pages/products/products.component.scss
+++ b/src/app/pages/products/products.component.scss
@@ -110,9 +110,10 @@
 }
 
 thead {
-  th:first-child, th:nth-child(2), th:nth-child(3), th:nth-child(4), th:nth-child(5), th:nth-child(6), th:nth-child(7), th:nth-child(8) {
-      &:hover {
-          cursor: pointer
-      }
+  cursor: pointer;  
+  user-select: none;
+
+  th:last-child {
+      cursor: default;
   }
 }


### PR DESCRIPTION
### ProductsComponent fejléc:
- szám szerinti rendezést mutat az ikon: id, address , catID, price
- abc szerinti rendezést mutat az ikon: name, type, description, featured, active
- az edit oszlopban nem jelenik meg rendező ikon

### CustomersComponent fejléc:
- szám szerinti rendezést mutat az ikon: id, address 
- abc szerinti rendezést mutat az ikon: firstName, lastName, email, active 
- az edit oszlopban nem jelenik meg rendező ikon

### OrdersComponent fejléc:
- szám szerinti rendezést mutat az ikon: id, customerID, producID, amount 
- abc szerinti rendezést mutat az ikon: status 
- az edit oszlopban nem jelenik meg rendező ikon.

### BillComponent fejléc:
- szám szerinti rendezést mutat az ikon: id, orderID, amount 
- abc szerinti rendezést mutat az ikon: status 
- az edit oszlopban nem jelenik meg rendező ikon.

### CSS
A fejléc css-ekben annyi módosítottam a Sándor által korábban módosított thead részen, hogy az egész fejlécen pointer a mutató, kivéve az edit/delete oszlop felett (th:last-child), ahol default és sehol sem enged szöveget kiválasztani.